### PR TITLE
Wrap PushNotificationChannel into try/catch block

### DIFF
--- a/windows/RNNotifications/RNPushNotificationModule.cs
+++ b/windows/RNNotifications/RNPushNotificationModule.cs
@@ -60,13 +60,18 @@ namespace RNNotifications
 
         public override async void Initialize()
         {
-            var channel = await PushNotificationChannelManager.CreatePushNotificationChannelForApplicationAsync();
-            channel.PushNotificationReceived += OnPushNotification;
-            Debug.WriteLine(channel.Uri);
+            try {
+                var channel = await PushNotificationChannelManager.CreatePushNotificationChannelForApplicationAsync();
+                channel.PushNotificationReceived += OnPushNotification;
+                Debug.WriteLine(channel.Uri);
 
-            Context
-                .GetJavaScriptModule<RCTDeviceEventEmitter>()
-                .emit("remoteNotificationsRegistered", new { deviceToken = channel.Uri });
+                Context
+                    .GetJavaScriptModule<RCTDeviceEventEmitter>()
+                    .emit("remoteNotificationsRegistered", new { deviceToken = channel.Uri });
+            }
+            catch (Exception ex) {
+                Debug.WriteLine(ex);
+            }
         }
 
         private void OnPushNotification(PushNotificationChannel sender, PushNotificationReceivedEventArgs args)


### PR DESCRIPTION
try/catch block should prevent app from crashing in case if no network info is found i.e. device is not connected to the internet or in flight mode.